### PR TITLE
Support for no-color.org

### DIFF
--- a/lib/Term/ANSIColor.pm
+++ b/lib/Term/ANSIColor.pm
@@ -1204,6 +1204,15 @@ instead will just return the empty string or pass through the original
 text as appropriate.  This is intended to support easy use of scripts
 using this module on platforms that don't support ANSI escape sequences.
 
+=item NO_COLOR
+
+If this environment variable is set to a true value, all of the functions
+defined by this module (color(), colored(), and all of the constants not
+previously used in the program) will not output any escape sequences and
+instead will just return the empty string or pass through the original
+text as appropriate.  This is intended to make scripts
+using this module compliant with the L<https://no-color.org> manifest.
+
 =back
 
 =head1 COMPATIBILITY

--- a/lib/Term/ANSIColor.pm
+++ b/lib/Term/ANSIColor.pm
@@ -275,7 +275,7 @@ sub AUTOLOAD {
 
     # If colors are disabled, just return the input.  Do this without
     # installing a sub for (marginal, unbenchmarked) speed.
-    if ($ENV{ANSI_COLORS_DISABLED}) {
+    if ($ENV{ANSI_COLORS_DISABLED} or $ENV{NO_COLOR}) {
         return join(q{}, @_);
     }
 


### PR DESCRIPTION
Disabled color output if `NO_COLOR` is set, in addition to the pre-existing `ANSI_COLORS_DISABLED`

- See #3 