### PR TITLE
NO_COLOR: the empty string should not disable color

### DIFF
--- a/lib/Term/ANSIColor.pm
+++ b/lib/Term/ANSIColor.pm
@@ -268,7 +268,7 @@ sub AUTOLOAD {
 
     # If colors are disabled, just return the input.  Do this without
     # installing a sub for (marginal, unbenchmarked) speed.
-    if ($ENV{ANSI_COLORS_DISABLED} || defined($ENV{NO_COLOR})) {
+    if ($ENV{ANSI_COLORS_DISABLED} || length($ENV{NO_COLOR})) {
         return join(q{}, @_);
     }
 
@@ -290,7 +290,7 @@ sub AUTOLOAD {
     ## no critic (ValuesAndExpressions::ProhibitImplicitNewlines)
     my $eval_result = eval qq{
         sub $AUTOLOAD {
-            if (\$ENV{ANSI_COLORS_DISABLED} || defined(\$ENV{NO_COLOR})) {
+            if (\$ENV{ANSI_COLORS_DISABLED} || length(\$ENV{NO_COLOR})) {
                 return join(q{}, \@_);
             } elsif (\$AUTOLOCAL && \@_) {
                 return PUSHCOLOR('$escape') . join(q{}, \@_) . POPCOLOR;
@@ -388,7 +388,7 @@ sub color {
     my (@codes) = @_;
 
     # Return the empty string if colors are disabled.
-    if ($ENV{ANSI_COLORS_DISABLED} || defined($ENV{NO_COLOR})) {
+    if ($ENV{ANSI_COLORS_DISABLED} || length($ENV{NO_COLOR})) {
         return q{};
     }
 
@@ -513,7 +513,7 @@ sub colored {
     }
 
     # Return the string unmolested if colors are disabled.
-    if ($ENV{ANSI_COLORS_DISABLED} || defined($ENV{NO_COLOR})) {
+    if ($ENV{ANSI_COLORS_DISABLED} || length($ENV{NO_COLOR})) {
         return $string;
     }
 
@@ -1201,12 +1201,12 @@ escape sequences.
 
 =item NO_COLOR
 
-If this environment variable is set to any value, it suppresses generation of
-escape sequences the same as if ANSI_COLORS_DISABLED is set to a true value.
-This implements the L<https://no-color.org/> informal standard.  Programs that
-want to enable color despite NO_COLOR being set will need to unset that
-environment variable before any constant or function provided by this module
-is used.
+If this environment variable is set to any value (other than the empty string),
+it suppresses generation of escape sequences the same as if
+ANSI_COLORS_DISABLED is set to a true value.  This implements the
+L<https://no-color.org/> informal standard.  Programs that want to enable color
+despite NO_COLOR being set will need to unset that environment variable before
+any constant or function provided by this module is used.
 
 =back
 

--- a/t/module/basic.t
+++ b/t/module/basic.t
@@ -114,10 +114,10 @@ is(
 );
 is((BLUE 'testing'), 'testing', 'Constant support for NO_COLOR');
 local $ENV{NO_COLOR} = q{};
-is(color('blue'), q{}, 'color support for NO_COLOR with empty string');
+is(color('blue'), qq{\e[34m}, 'color support for NO_COLOR with empty string');
 is(
     (RED 'testing'),
-    'testing',
+    "\e[31mtesting",
     'Constant support for NO_COLOR with empty string',
 );
 delete $ENV{NO_COLOR};


### PR DESCRIPTION
According to no-color.org, which is cited as the authority behind the `NO_COLOR` environment variable:

>  Command-line software which adds ANSI color to its output by default should check for a NO_COLOR environment variable that, when present and not an empty string (regardless of its value), prevents the addition of ANSI color.

This branch brings the behavior of Term::ANSIColor in line with that spec.

Thanks very much for Term::ANSIColor, I use it often!